### PR TITLE
Ensembl BioMart connection problems

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: conclus
 Title: ScRNA-seq Workflow CONCLUS - From CONsensus CLUSters To A Meaningful CONCLUSion
-Version: 0.99.317
+Version: 0.99.318
 Authors@R: c(
     person("Ilyess", "Rachedi", email = "ilyessr@hotmail.fr", role = "cre"),
     person("Nicolas", "Descostes", email = "nicolas.descostes@embl.it", role = "aut"),

--- a/R/sharedInternals.R
+++ b/R/sharedInternals.R
@@ -194,7 +194,7 @@ createDirectory <- function(dataDirectory, directory){
     repeat{
     message("# Attempt ", c, "/5 # ",
             "Connection to Ensembl ... ")
-    ensembl <- try(useMart(biomart, dataset=dataset), silent=FALSE)
+    ensembl <- try(useEnsembl(biomart, dataset=dataset), silent=FALSE)
 
     if(isTRUE(is(ensembl, "try-error"))){
         c <- c + 1


### PR DESCRIPTION
Hi Ilyess,

I just read your post on the Biocondctor mailing list regarding connection problems with biomaRt.  In the devel version of biomaRt I've move the detection & fix for those SSL problems out of the package loading process, and they now get executed when a user runs `useEnsembl()`.  This is because the problems are really Ensembl specific, and I didn't like lowering security settings for all connections a user tries to make.  This should also remove the ~10 second delay on loading the package, and allows biomaRt to store the results of the test in its cache, which means the fix persists between sessions.

This pull request swaps `useMart()` for `useEnsembl()`, and I'm then able to build the vignette on my Ubuntu 20.04 system.

